### PR TITLE
Separate control keywords from scope keywords

### DIFF
--- a/syntaxes/clue.json
+++ b/syntaxes/clue.json
@@ -83,8 +83,12 @@
 			]
 		},
 		{
-			"match": "\\b(if|elseif|else|for|of|in|with|while|meta|global|until|local|fn|method|return|loop|static|enum|continue|break|try|catch|match|default)\\b",
+			"match": "\\b(if|elseif|else|for|of|in|with|while|meta|until|fn|method|return|loop|enum|continue|break|try|catch|match|default)\\b",
 			"name": "keyword.control.clue"
+		},
+		{
+			"match": "\\b(local|global|static)\\b",
+			"name": "keyword.scope.clue"
 		},
 		{
 			"match": "(?<![^.]\\.|:)\\b(false|nil|true|_G|_VERSION|math\\.(pi|huge))\\b|(?<![.])\\.{3}(?!\\.)",


### PR DESCRIPTION
The scoping keywords are now a different color just like lua syntax highlightin
<img width="317" alt="new syntax highlighting" src="https://user-images.githubusercontent.com/87304130/173007377-7db9fa5f-6f45-42b2-befe-671fb3245e87.png">
g