### PR TITLE
Fix workspace check and add more logging

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -22,7 +22,9 @@ const workspaceFolders: WorkspaceFolder[] = [];
 let isClueAvailable: boolean = false;
 
 connection.onInitialize(params => {
+    connection.console.info(`Initializing Clue Language Server`);
     workspaceFolders.push(...(params.workspaceFolders || []));
+    connection.console.info(`Workspace folders: ${JSON.stringify(workspaceFolders.map(wf => fileURLToPath(wf.uri)))}`);
     return {
         capabilities: {
             textDocumentSync: {
@@ -35,56 +37,75 @@ connection.onInitialize(params => {
 });
 
 connection.onInitialized(async () => {
-    connection.client.register(DidChangeConfigurationNotification.type, undefined);
+    connection.console.info('Clue Language Server initialized');
+    await connection.client.register(DidChangeConfigurationNotification.type, undefined);
     await checkCluePath();
     await handleAllFiles();
 });
 
 connection.onDidChangeConfiguration(async () => {
+    connection.console.info('Clue Language Server configuration changed');
     await checkCluePath();
     await handleAllFiles();
 });
 
 documents.onDidOpen(async change => {
+    connection.console.info(`Opened ${fileURLToPath(change.document.uri)}`);
     await handleChangedFile(change.document);
 })
 
 documents.onDidSave(async change => {
+    connection.console.info(`Saved ${fileURLToPath(change.document.uri)}`);
     await handleChangedFile(change.document);
 });
 
 const checkCluePath = async () => {
+    connection.console.info('Checking Clue path');
     const config = await connection.workspace.getConfiguration({ section: 'clue' });
     const cluePath = config['path'] || 'clue';
     const command = `${cluePath} -V`;
+    connection.console.info(`Running ${command}`);
     const output = await promisify(exec)(command).catch(e => ({ isError: true, ...e }));
     const versionMatch = /^clue ((\d+)\.(\d+)\.\d+(-\w+)?)$/.exec(output.stdout.trim());
     if (!versionMatch) {
-        connection.window.showErrorMessage('Clue is not available. Please install it and configure the path to it in your settings.');
+        const message = 'Clue is not available. Please install it and configure the path to it in your settings.';
+        connection.console.error(message);
+        connection.window.showErrorMessage(message);
         isClueAvailable = false;
         return;
     }
     const [_, version, major, minor] = versionMatch || [];
     // must be Clue 3.2 or higher
     if (major !== '3' || Number.parseInt(minor) < 2) {
-        connection.window.showErrorMessage(`Clue ${version} is not supported. Please install Clue 3.2 or higher and configure the path to it in your settings.`);
+        const message = `Clue ${version} is not supported. Please install Clue 3.2 or higher and configure the path to it in your settings.`;
+        connection.console.error(message);
+        connection.window.showErrorMessage(message);
         isClueAvailable = false;
         return;
     }
     isClueAvailable = true;
-    connection.window.showInformationMessage(`Running Clue ${version}.`);
+    const message = `Running Clue ${version}.`;
+    connection.console.info(message);
+    connection.window.showInformationMessage(message);
 };
 
 const handleAllFiles = async () => {
     if (!isClueAvailable) {
         return;
     }
-    const paths = workspaceFolders.map(({ uri }) => fileURLToPath(uri));
+    connection.console.info('Checking all files');
+    const workspaceFolderPaths = workspaceFolders.map(({ uri }) => fileURLToPath(uri));
+    connection.console.info(`Workspace folders: ${JSON.stringify(workspaceFolderPaths)}`);
+    connection.console.info(`Documents: ${JSON.stringify(documents.all().map(d => fileURLToPath(d.uri)))}`);
+    const paths = [...workspaceFolderPaths];
     for (const { uri } of documents.all()) {
-        if (!paths.some(path => uri.startsWith(path))) {
+        const path = fileURLToPath(uri);
+        if (!workspaceFolderPaths.some(wfp => path.startsWith(wfp))) {
+            // document is not in a workspace
             paths.push(fileURLToPath(uri));
         }
     }
+    connection.console.info(`Paths to run Clue on: ${JSON.stringify(paths)}`);
     for (const path of paths) {
         await runClue(path);
     }
@@ -94,15 +115,25 @@ const handleChangedFile = async (document: TextDocument) => {
     if (!isClueAvailable) {
         return;
     }
+    connection.console.info(`Checking ${fileURLToPath(document.uri)}`);
     // check if document is a workspace
     const workspaceFolder = workspaceFolders.find(folder => document.uri.startsWith(folder.uri));
-    await runClue(fileURLToPath((workspaceFolder || document).uri));
+    if (workspaceFolder) {
+        const path = fileURLToPath(workspaceFolder.uri);
+        connection.console.info(`Document is in workspace: ${path}`);
+        await runClue(path);
+    }
+    else {
+        connection.console.info(`Document is not in workspace`);
+        await runClue(fileURLToPath(document.uri));
+    }
 };
 
 const runClue = async (path: string) => {
     const config = await connection.workspace.getConfiguration({ section: 'clue' });
     const cluePath = config['path'] || 'clue';
     const command = `${cluePath} -D ${path}`;
+    connection.console.info(`Running ${command}`);
     const env: { [key: string]: string } = { };
     for (const [key, value] of Object.entries(config['env'] || { })) {
         if (typeof value === 'object') {
@@ -114,8 +145,12 @@ const runClue = async (path: string) => {
     }
     const output = await promisify(exec)(command, { env }).catch(e => ({ isError: true, ...e }));
     const { stdout, stderr, isError } = output;
-    stdout && connection.console.log(stdout);
-    stderr && connection.console.log(stderr);
+    if (stdout) {
+        connection.console.info('Clue output:\n' + stdout);
+    }
+    if (stderr) {
+        connection.console.info('Clue errors:\n' + stderr);
+    }
     const emptyError = () => ({
         path: '',
         line: 0,
@@ -147,9 +182,12 @@ const runClue = async (path: string) => {
     }
     if (isError && errors.length === 0) {
         // something else went wrong
-        connection.window.showErrorMessage('Clue encountered an error. Please check the output for more information.');
+        const message = 'Clue encountered an error. Please check the output for more information.';
+        connection.console.error(message);
+        connection.window.showErrorMessage(message);
         return;
     }
+    connection.console.info(`Found ${errors.length} errors`);
     // collect successfully compiled files from stdout
     const compiledFiles: string[] = [];
     for (const line of stdout.split('\n')) {
@@ -160,6 +198,7 @@ const runClue = async (path: string) => {
         const [_, path] = compiledFileMatch;
         compiledFiles.push(path);
     }
+    connection.console.info(`Found ${compiledFiles.length} compiled files`);
     // need to find the end of each error
     const documentsCache: { [path: string]: TextDocument } = { };
     const getLine = async (
@@ -203,6 +242,7 @@ const runClue = async (path: string) => {
             source: 'clue',
         });
     }
+    connection.console.info('Sending diagnostics');
     // send diagnostics for files with errors
     for (const [uri, diagnostics] of Object.entries(diagnosticsByUri)) {
         connection.sendDiagnostics({ uri, diagnostics });


### PR DESCRIPTION
I have fixed a bug that may have been causing some strange behaviour.

On any change, the extension should run Clue on the workspace. However, I had set up the extension to ensure that any open Clue files that are not part of the workspace are also compiled separately. The check to determine whether a file is part of a workspace had a bug – I was comparing paths with URIs!

See lines 97 to 107 for the fix. Line 120 should be fine since in this case we're comparing URIs with URIs.

I have also adding more logging to the extension to help with debugging.